### PR TITLE
Changed pubDate to be RFC-822 like.

### DIFF
--- a/cmd/gen.go
+++ b/cmd/gen.go
@@ -32,7 +32,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/gogap/types"
 	"github.com/goware/urlx"
 	"github.com/kennygrant/sanitize"
 	"github.com/rjocoleman/get_iplayer_rss/utils"
@@ -139,7 +138,7 @@ var genCmd = &cobra.Command{
 				item.ITunesAuthor = episode.Name
 				item.ITunesSummary = episode.Desc
 				item.ITunesImage.Href = episode.Thumbnail
-				item.PubDate = types.DateTime(time.Unix(episode.TimeAdded, 0))
+				item.PubDate = time.Unix(episode.TimeAdded, 0).Format("Mon, 02 Jan 2006 15:04:05 MST")
 
 				_, filename := filepath.Split(episode.Filename)
 				webUrl, _ := urlx.Parse(url)

--- a/utils/podcast.go
+++ b/utils/podcast.go
@@ -3,7 +3,6 @@ package utils
 import (
 	"encoding/xml"
 
-	"github.com/gogap/types"
 )
 
 // PodcastRSS ...
@@ -54,7 +53,7 @@ type PodcastItem struct {
 		Type   string `xml:"type,attr,omitempty"`
 	} `xml:"enclosure,omitempty"`
 	GUID           string         `xml:"guid,omitempty"`
-	PubDate        types.DateTime `xml:"pubDate,omitempty"`
+	PubDate        string         `xml:"pubDate,omitempty"`
 	ITunesDuration string         `xml:"itunes:duration,omitempty"`
 }
 


### PR DESCRIPTION
The UNIX-style pubDate was not playing well with Apple Podcast app - the 2-digit year would be shown from 00 (e.g. 0018).  Additionally, the RSS 2.0 spec says pubDate should conform to RFC822 but with a 4-digit year.  As the golang RFC822 format is a 2 digit year, this change creates a RFC822-like pubDate with a 4 digit year.

Also it will remove a dependency.